### PR TITLE
fix: drop semantic-release git commit-back to work with protected master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npx --yes -p semantic-release@24 -p @semantic-release/changelog@6 -p @semantic-release/git@10 semantic-release
+      - run: npx --yes -p semantic-release@24 semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,12 +3,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    ["@semantic-release/npm", { "npmPublish": false }],
-    ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }],
     "@semantic-release/github"
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Single pipeline in `.github/workflows/ci.yml` (push + PR to `master`):
 - **lint** and **test** run in parallel on Node 10.
 - **build** (Node 10) runs `build:gh-pages`, adds `404.html` (copy of `index.html`, the GitHub Pages SPA fallback) and `.nojekyll`, and uploads the Pages artifact.
 - **deploy** (master pushes only) publishes to GitHub Pages: <https://commitblob.github.io/folioAngular/>.
-- **release** (master pushes only, Node 22 — semantic-release needs ≥ 20) runs semantic-release via npx (deliberately *not* in devDependencies, to keep the Node 10 lockfile clean). Config in `.releaserc.json`: analyses Conventional Commits, bumps `package.json`, writes `CHANGELOG.md`, pushes a `chore(release): x.y.z [skip ci]` commit, tags `vX.Y.Z`, and publishes a GitHub Release. The version lives only in `package.json` — nothing in the app reads it.
+- **release** (master pushes only, Node 22 — semantic-release needs ≥ 20) runs semantic-release via npx (deliberately *not* in devDependencies, to keep the Node 10 lockfile clean). Config in `.releaserc.json`: analyses Conventional Commits, then creates a git tag `vX.Y.Z` and publishes a GitHub Release with auto-generated notes via `@semantic-release/github`. It does **not** commit anything back to the repo (no `@semantic-release/git`/`changelog`/`npm` plugins) — `master` is a protected branch, so the source of truth for versions is the git tags + GitHub Releases page, not `package.json`. Nothing in the app reads the version.
 
 Use Conventional Commit messages (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major); other types don't trigger releases.
 


### PR DESCRIPTION
The @semantic-release/git plugin pushes the release commit (CHANGELOG + version bump) directly to master, which the branch-protection rule rejects (GH006: changes must be made through a pull request). Drop the git/changelog/npm plugins so releases only create a git tag and a GitHub Release with auto-generated notes via @semantic-release/github — no push to master, protection stays intact. Git tags and the Releases page are the version source of truth.