### PR TITLE
docs: add LLM-optimised wiki with staleness linter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Wiki
+
+For a dense map of this repo (directory ToC, convention/gotcha registry, file/test/fixture matrix) and 4 domain pages on routing/animation, the feature-page pattern (and its real deviations), shared infrastructure, and testing, start at **[docs/wiki/index.md](./docs/wiki/index.md)**. It is anchored to git SHAs and checked for staleness by `node docs/wiki/lint/lint.js` (see [docs/wiki/lint/README.md](./docs/wiki/lint/README.md)) — if that command reports `STALE` pages, treat their claims as unverified until re-checked against current code.
+
 ## Toolchain
 
 Node 10 required (see `.nvmrc`) — node-sass 4.x in the lockfile does not build on newer Node versions. Run `nvm use` before installing.
@@ -25,7 +29,7 @@ Angular 5 portfolio SPA (Angular CLI 1.7.3). All data is static JSON fetched via
 
 ### Feature modules (`src/app/+*-page/`)
 
-Each page is a lazy-loaded feature module using the `+` prefix convention. Every page folder contains the same four files: `*.component.ts`, `*.module.ts`, `*.routes.ts`, `*.service.ts`. Services fetch static JSON from `src/assets/data/`; components are presentational.
+Each page is a lazy-loaded feature module using the `+` prefix convention. Most page folders follow a four-file shape — `*.component.ts`, `*.module.ts`, `*.routes.ts`, `*.service.ts` — but several deviate (e.g. `+faqs-page` has no `faqs-page.component.ts`; `+portfolio-page/project-details` has no `.routes.ts` and is routed eagerly). See [feature-page-pattern.md](./docs/wiki/feature-page-pattern.md) for the full pattern and every deviation before assuming uniformity. Services fetch static JSON from `src/assets/data/`; components are presentational.
 
 Routes are registered in `app.routes.ts` via string-based `loadChildren` (Angular 5 pre-Ivy syntax). Each route carries a `data: { animation: '...' }` key consumed by the router animation in `app.component.ts`.
 
@@ -56,4 +60,10 @@ Single pipeline in `.github/workflows/ci.yml` (push + PR to `master`):
 
 Use Conventional Commit messages (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major); other types don't trigger releases.
 
-- **Docker** (alternative deployment): nginx serves the `dist/` folder; `nginx-custom.conf` uses `try_files $uri $uri/ /index.html` for SPA routing.
+- **Docker**: no `Dockerfile` or nginx config exists in this repo as of the current wiki anchor SHA — a prior version of this file described an nginx-based deployment that is not present in the tracked tree. Verify before relying on it; GitHub Pages (above) is the only deployment path currently wired in CI.
+
+## Definition of Done
+
+- `npm run lint` exits 0.
+- `npm run test:ci` exits 0 (enforces the coverage thresholds in `jest.config.js`).
+- `node docs/wiki/lint/lint.js` exits 0 (no stale wiki anchors) if `docs/wiki/` or any file it anchors changed.

--- a/docs/wiki/feature-page-pattern.md
+++ b/docs/wiki/feature-page-pattern.md
@@ -1,0 +1,64 @@
+---
+type: Convention
+title: Feature-Page Pattern
+description: The canonical component/module/routes/service shape used by the six lazy-loaded feature pages, and every real deviation from it.
+resource: https://github.com/commitBlob/folioAngular/blob/c4391ece5b07a47b84f5591808f3588a37f9ea7c/src/app
+tags: [convention, routing, angular-module, footgun]
+timestamp: 2026-07-08T00:00:00Z
+anchors:
+  - src/app/+about-page/about-page.component.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+about-page/about-page.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+about-page/about-page.routes.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+about-page/about-page.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+faqs-page/faqs-block.component.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+faqs-page/faqs-page.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+faqs-page/faqs-page.routes.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+contact-page/contact-page.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+contact-page/contact-page.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+portfolio-page/project-details/project-details.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+experience-page/experience-page.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+skills-page/skills-page.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+portfolio-page/portfolio-page.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+experience-page/experience-page.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+portfolio-page/project-details/project-details.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+---
+
+# Feature-Page Pattern
+
+## Why this page exists
+
+CLAUDE.md (repo root) claims: "Every page folder contains the same four files: `*.component.ts`, `*.module.ts`, `*.routes.ts`, `*.service.ts`." This is **false** for 3 of the 6 feature pages, in ways that would mislead an agent adding a 7th page or refactoring an existing one. This page compresses the real pattern plus every deviation, spanning ~30 files across 6 folders — well over the compression bar, and none of it is visible from reading any single file.
+
+## The canonical shape (about, portfolio, skills — the pages that actually match CLAUDE.md)
+
+1. **`*.routes.ts`** exports `const XRoutes: ModuleWithProviders = RouterModule.forChild(routes)`, where `routes: Routes` is a local const with one entry `{ path: '', component: XComponent }`. Example, `src/app/+about-page/about-page.routes.ts:6-12`:
+   ```ts
+   const routes: Routes = [{ path: '', component: AboutPageComponent }];
+   export const AboutPageRoutes: ModuleWithProviders = RouterModule.forChild(routes);
+   ```
+2. **`*.module.ts`** imports `CommonModule` + the page's own `XRoutes`, declares `XComponent`, and provides `XService` — never provides the service on the component itself. `src/app/+about-page/about-page.module.ts:10-21`.
+3. **`*.service.ts`** is `@Injectable()` (module-provided, see above), injects `HttpClient`, does `this.http.get('./assets/data/projectdissimilar/<name>.json').catch(this.handleError)` per method, and carries a private `handleError` copy-pasted verbatim across every HTTP service (log `'Whoops, something went wrong'`, rethrow via `Observable.throw`). `src/app/+about-page/about-page.service.ts:12-28`.
+4. **`*.component.ts`** is presentational, injects the service (and often `Meta`/`Title`/`MetaTagsService`), calls the service in `ngOnInit`.
+5. Registered lazily in root `app.routes.ts` via string `loadChildren: 'app/+x-page/x-page.module#XPageModule'` — see [routing-and-animation.md](./routing-and-animation.md).
+
+## Deviations (real, current, code-confirmed)
+
+| Page | Deviation | Citation |
+|---|---|---|
+| `+faqs-page` | **No `faqs-page.component.ts`.** The routed component is `FaqsBlockComponent` (selector `faqs-block`), declared in `FaqsPageModule` and routed by `FaqsPageRoutes`. | `src/app/+faqs-page/faqs-page.routes.ts:6,11`, `src/app/+faqs-page/faqs-page.module.ts:6,18` |
+| `+faqs-page` | Its route in root `app.routes.ts` has **no `data.animation`** — the only lazy page missing this key (`**` also lacks it, but that's the wildcard). | `src/app/app.routes.ts:40-43` |
+| `+faqs-page` | `FaqsBlockComponent.navigateBack()` clears `this.faqs = []` before calling `location.back()` — an explicit workaround comment: `// workaround to prevent animation trigger when user leaves the page`. `ngOnInit` also defers assigning the fetched list by `setTimeout(..., 500)` — comment `// don't rush`. Both are non-obvious timing couplings to the router animation, not bugs to "fix" on sight. | `src/app/+faqs-page/faqs-block.component.ts:26-30,32-37` |
+| `+contact-page` | **`ContactPageService` makes no HTTP call at all.** `submitForm()` is a stub: `return Observable.of(null);`. There is no `contact.json` and no `HttpClient` import in the service. | `src/app/+contact-page/contact-page.service.ts:6-11` |
+| `+contact-page` | Module additionally imports `FormsModule`, `MaterialModule`, `ReactiveFormsModule`, and `SharedModule` — no other feature module imports all four. | `src/app/+contact-page/contact-page.module.ts:14-21` |
+| `+portfolio-page/project-details/` (nested) | **No `.routes.ts` file at all.** It is not lazy-loaded — `ProjectDetailsComponent` is imported directly into root `app.routes.ts` and routed eagerly at `path: 'portfolio/:project'`. Its module only declares+exports the component and provides `ProjectDetailsService`; nothing calls `RouterModule.forChild` for it. | `src/app/+portfolio-page/project-details/project-details.module.ts:10-26`, `src/app/app.routes.ts:6,45-47` |
+| `+portfolio-page/project-details/` | Its module is imported by `SharedModule` (not by `PortfolioPageModule`), so the eager route can resolve the component without going through the lazy portfolio chunk. See [shared-infrastructure.md](./shared-infrastructure.md). | `src/app/shared/shared.module.ts:10,24` |
+| `+experience-page` | Two nested child components, `experience-projects/experience-projects.component.ts` and `career-timeline/career-timeline.component.ts`, have **no per-folder module** — both are declared directly in the parent `ExperiencePageModule`. | `src/app/+experience-page/experience-page.module.ts:9-10,17-21` |
+| `+experience-page` | Service method is named `getProjectsList()` (not `getProjects()` like portfolio's identically-shaped call) and wraps the response: `.map((res: any[]) => ({ payload: res }))` before `.catch`. Don't assume symmetry with `PortfolioPageService.getProjects()`, which returns the raw array. | `src/app/+experience-page/experience-page.service.ts:13-17` vs `src/app/+portfolio-page/portfolio-page.service.ts:12-14` |
+| `+skills-page` | Only service with a typed return: `getSkillsList(): Observable<SkillsInterface[]>` (`SkillsInterface` in `skills.interface.ts`). Every other service returns `Observable<any>`. | `src/app/+skills-page/skills-page.service.ts:15`, `src/app/+skills-page/skills.interface.ts:1-7` |
+
+## Net effect for an agent adding a new page
+
+- Default to the about/portfolio/skills shape (4 files, `forChild` routes, module-level service provider, copy the `handleError` block verbatim).
+- Do not assume a `*-page.component.ts` filename exists — check the module's `declarations` first (faqs breaks this).
+- Do not assume every feature has a `.routes.ts` — project-details doesn't, because it's eagerly routed from root.
+- If the new page needs no backend data, model it on contact (`Observable.of(...)` stub), not on the HTTP services.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,127 @@
+---
+type: Index
+title: folioAngular Wiki — Dense Map
+description: One-pass map of the folioAngular Angular 5 portfolio SPA — directories, commands, conventions, and the file/test/fixture matrix.
+resource: https://github.com/commitBlob/folioAngular/blob/c4391ece5b07a47b84f5591808f3588a37f9ea7c
+tags: [index, map, angular, portfolio-spa]
+timestamp: 2026-07-08T00:00:00Z
+anchors:
+  - package.json@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - .github/workflows/ci.yml@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - .angular-cli.json@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - .releaserc.json@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/index.html@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.routes.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.html@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - jest.config.js@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/shared.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/navigation/navigation-items.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/navigation/navigation.inteface.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/browser-detect/browser-detect.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/meta-tags/meta-tags.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+about-page/about-page.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+---
+
+# folioAngular — Dense Map
+
+Angular 5 (CLI 1.7.3) portfolio single-page app. No backend — every "API" call is `HttpClient.get()` against a static JSON file under `src/assets/data/projectdissimilar/`. 189 tracked files total; ~90 TypeScript sources under `src/app/`.
+
+**Repo verdict:** small and highly greppable — one concept ≈ one small file for most of the tree. This map plus 4 domain pages is the whole wiki; do not expect (or add) a page per file.
+
+Anchor SHA for this wiki build: `c4391ece5b07a47b84f5591808f3588a37f9ea7c` (branch `master`). Freshness is enforced by the linter — see [lint/README.md](./lint/README.md).
+
+## Directory table of contents
+
+| Path | What lives here |
+|---|---|
+| `src/app/+about-page/`, `+contact-page/`, `+experience-page/`, `+faqs-page/`, `+portfolio-page/`, `+skills-page/` | Lazy-loaded feature modules, one per route. See [feature-page-pattern.md](./feature-page-pattern.md). |
+| `src/app/404-page/` | `PageNotFoundComponent` + `PageNotFoundModule`, eagerly imported into `AppModule` (not lazy). |
+| `src/app/shared/` | Cross-cutting infra: `SharedModule`, `MaterialModule`, navigation, browser detection, meta tags. See [shared-infrastructure.md](./shared-infrastructure.md). |
+| `src/app/app.routes.ts`, `animations.ts`, `app.component.*` | Root route table + router-transition animation wiring. See [routing-and-animation.md](./routing-and-animation.md). |
+| `src/assets/data/projectdissimilar/*.json` | The entire "backend" — 10 static JSON fixtures fetched by feature services. |
+| `src/assets/styles/` | All SCSS. Single entry point `src/assets/styles/main.scss` (wired via `.angular-cli.json:19-21`). **No component has `styleUrls`** — do not add one without checking this convention first. |
+| `src/assets/fonts/` | Self-hosted FontAwesome webfonts. |
+| `src/environments/` | `environment.ts` (`{production:false}`) / `environment.prod.ts` — only `production` flag, nothing else is read from it. |
+| `src/testing/meta-stubs.ts` | Shared Jest stubs for `Meta`/`Title`/`MetaTagsService`, excluded from coverage. See [testing.md](./testing.md). |
+| `.github/workflows/ci.yml` | Single pipeline: lint + test → build → deploy (Pages) / release (semantic-release). |
+| `docs/wiki/` | This wiki. `docs/sass_structure.txt` is a pre-existing, unrelated note — leave as is. |
+
+## Entry points + exact commands
+
+Requires **Node 10** (`.nvmrc:1` = `10`) — `node-sass@4.x` in the lockfile does not build on newer Node. Run `nvm use` before `npm ci`.
+
+| Purpose | Command | Source |
+|---|---|---|
+| Install | `npm ci` (after `nvm use`) | — |
+| Dev server | `npm start` → `ng serve --open --port 8888` | `package.json:8` |
+| Dev build | `npm run build` → `ng build` | `package.json:9` |
+| Prod build | `npm run build:prod` → `ng build --prod` | `package.json:10` |
+| CI/Pages build | `npm run build:gh-pages` → `ng build --prod --base-href /folioAngular/` | `package.json:11` |
+| Unit tests | `npm test` → `jest` | `package.json:12` |
+| Tests, watch | `npm run test:watch` → `jest --watch` | `package.json:13` |
+| Tests, CI mode + coverage | `npm run test:ci` → `jest --ci --coverage --runInBand` | `package.json:14` |
+| Lint | `npm run lint` → `ng lint` | `package.json:15` |
+
+CI job graph (`.github/workflows/ci.yml`): `lint` and `test` run in parallel on Node 10 (`node-version-file: .nvmrc`) → `build` (`needs: [lint, test]`, Node 10, runs `build:gh-pages`, then copies `dist/` to `site/`, adds `site/404.html` = copy of `index.html` and `site/.nojekyll`) → `deploy` (`needs: build`, push-to-master only, `actions/deploy-pages@v4`). `release` (`needs: [lint, test]`, push-to-master only) runs on **Node 22** (pinned, not `.nvmrc`) via `npx --yes -p semantic-release@24 semantic-release` — semantic-release is deliberately absent from `devDependencies` to keep the Node-10 lockfile clean (`.github/workflows/ci.yml:75-80`).
+
+## Convention / rule registry
+
+Facts an agent cannot get from a single grep — read this before editing.
+
+| Rule | Detail | Citation |
+|---|---|---|
+| Lazy route module syntax | Pre-Ivy **string** `loadChildren`, form `'app/+X-page/x-page.module#XPageModule'` (app-root-relative path, `#` before class name). Cannot be changed to dynamic-import syntax without an Angular upgrade. | `src/app/app.routes.ts:17,22,27,32,37,42` |
+| `.routes.ts` export shape | Every feature `*.routes.ts` exports `const XRoutes: ModuleWithProviders = RouterModule.forChild(routes)` — not a raw `Routes` array — and is imported straight into the module's `imports`. | `src/app/+about-page/about-page.routes.ts:6-12` |
+| Services live in module `providers` | Never provided in a component; every feature module's `@NgModule({ providers: [XService] })`. | `src/app/+about-page/about-page.module.ts:18-20` |
+| JSON fetch URLs | Always the literal relative string `'./assets/data/projectdissimilar/<name>.json'` passed to `HttpClient.get()` — not an environment-driven base URL. | `src/app/+about-page/about-page.service.ts:13,17` |
+| Duplicated error handler | Every HTTP-backed service repeats an identical private `handleError(error)` → logs `'Whoops, something went wrong'` to console and does `Observable.throw(errMsg)`. Not extracted to a shared util — if you add a service, copy this pattern rather than inventing a new one. | `src/app/+about-page/about-page.service.ts:23-28` (representative; same body in contact/experience/faqs/portfolio/project-details/skills services) |
+| RxJS 5 patch-operator style | `import 'rxjs/add/operator/catch'` / `.../map`, `Observable.throw`, `Observable.of`, `Observable.forkJoin` — **not** pipeable `pipe(catchError(...))` RxJS 6 style. Mixing styles will break the build. | `src/app/+about-page/about-page.service.ts:4-6` |
+| No component styles | All SCSS routes through the single entry `src/assets/styles/main.scss` (`.angular-cli.json:19-21`); no `@Component` in the repo declares `styleUrls`. | `.angular-cli.json:19-21` |
+| `faqs` and `**` routes have no `data.animation` | `getRouteAnimation()` returns `undefined` for these paths; the `'* <=> *'` transition still fires but with an undefined trigger value. Don't assume every route animates identically. | `src/app/app.routes.ts:40-43,49-52` |
+| Route animation reads `activatedRouteData`, not `route.data` | `getRouteAnimation(outlet) { return outlet.activatedRouteData.animation; }`, called with the `#route="outlet"` template ref on `<router-outlet>`. | `src/app/app.component.ts:29-31`, `src/app/app.component.html:10-11` |
+| Base href differs by build target | Dev/local: `<base href="/">` in `src/index.html:6`. GH Pages CI build overrides via `--base-href /folioAngular/` (`package.json:11`). Serving a `build:gh-pages` output at root (or vice versa) breaks all asset paths. | `src/index.html:6`, `package.json:11` |
+| Coverage thresholds (global, hard gate) | `statements: 90, branches: 80, functions: 90, lines: 90`. `test:ci` (`jest --ci --coverage --runInBand`) fails the run if unmet. | `jest.config.js:21-28` |
+| Coverage excludes | `*.module.ts`, `*.routes.ts`, `*.spec.ts`, `src/testing/**` are excluded from `collectCoverageFrom` — don't expect coverage numbers to include DI wiring. | `jest.config.js:14-20` |
+| Conventional Commits drive releases | `fix:`→patch, `feat:`→minor, `feat!:`/`BREAKING CHANGE`→major; other prefixes (`docs:`, `chore:`, …) do not trigger a release. `.releaserc.json` has no git/changelog/npm plugin — `master` is protected, versions live only in git tags + GitHub Releases, nothing in `package.json` is bumped. | `.releaserc.json:1-8` |
+| `NavigationInteface` filename/identifier typo | File is `navigation.inteface.ts` (missing "r"), interface is `NavigationInteface`. Grepping for "interface" will miss it; new code must import the misspelled name to match. | `src/app/shared/navigation/navigation.inteface.ts:1` |
+| Nav items ≠ full route set | `GlobalNavigation` (5 items: about/skills/experience/portfolio/contact) omits `faqs` entirely — `/faqs` is only reachable by direct URL. | `src/app/shared/navigation/navigation-items.ts:3-30` |
+| `SharedModule` re-exports `FormsModule` without importing it | `exports: [..., FormsModule, ...]` while only `ReactiveFormsModule` is in `imports` — legal Angular (re-export doesn't require import) but easy to misread as a bug. `forRoot()` returns `{ ngModule: SharedModule, providers: [] }` — a no-op used only by `AppModule`; feature modules import plain `SharedModule`. | `src/app/shared/shared.module.ts:19-27,32-37` |
+| `SharedModule` depends on a feature subfolder | `SharedModule` imports/exports `ProjectDetailsModule` from `../+portfolio-page/project-details/...` — shared infra reaching into a specific feature page. `ProjectDetailsComponent` is also routed **eagerly** (not lazy) directly from root `app.routes.ts:6,45-47`, unlike every other page. | `src/app/shared/shared.module.ts:10,24` |
+| CLAUDE.md's "same four files" claim is not accurate | See [feature-page-pattern.md](./feature-page-pattern.md) for every deviation (faqs has no `*-page.component`; contact service does no HTTP; project-details has no `.routes.ts`; experience's nested components have no per-folder module). Code wins — treat the four-file shape as the common case, not an invariant. | n/a — cross-file finding |
+| Docker deployment section in CLAUDE.md is unverified | CLAUDE.md (root) mentions `nginx-custom.conf` and an nginx Docker deployment; **no `Dockerfile` or `nginx*` file exists anywhere in the tracked tree** (confirmed via `git ls-files` glob, this run). Treat that CLAUDE.md paragraph as stale/aspirational until such a file is added. | n/a — absence confirmed against `git ls-files` |
+| Page `<title>` vs `MetaTagsService.roleTitle` disagree | `src/index.html:5` title says "AI Solution Architect & Lead Forward Deployed Engineer"; `MetaTagsService.roleTitle` (used by every page's dynamic `<title>` via `Title.setTitle`) says `'Senior Software Developer & Research Lead'`. Two sources of truth for the same fact — pick one before editing either. | `src/index.html:5`, `src/app/shared/meta-tags/meta-tags.service.ts:7` |
+| Browser gate is a string-equality allowlist, not a UA regex | `BrowserDetectService.chromeOrFirefoxCheck()` uses Bowser's `getBrowserName()` and passes only for the literal strings `'Chrome'` or `'Firefox'` — every other browser (including Edge, Safari, Chromium forks Bowser doesn't label exactly "Chrome") renders `BrowserUnsupportedComponent` instead of the app. | `src/app/shared/browser-detect/browser-detect.service.ts:8-13` |
+
+## File / test / fixture matrix
+
+| Domain | Key source file(s) | Spec(s) | JSON fixture(s) consumed |
+|---|---|---|---|
+| About | `+about-page/about-page.component.ts`, `.service.ts` | `about-page.component.spec.ts`, `about-page.service.spec.ts` | `profile_pictures.json`, `social_icons.json` |
+| Contact | `+contact-page/contact-page.component.ts`, `.service.ts` (no HTTP — `submitForm()` returns `Observable.of(null)`, `contact-page.service.ts:8-10`) | `contact-page.component.spec.ts`, `contact-page.service.spec.ts` | none |
+| Experience | `+experience-page/experience-page.component.ts`, `.service.ts`, nested `experience-projects/experience-projects.component.ts`, `career-timeline/career-timeline.component.ts` (both declared directly in `experience-page.module.ts:17-20`, no per-folder module) | `experience-page.component.spec.ts`, `.service.spec.ts`, `experience-projects.component.spec.ts`, `career-timeline.component.spec.ts` | `projects.json` (wrapped `{payload: res}`, `experience-page.service.ts:13-17`), `positions.json`, `education.json`, `career_progression.json` |
+| FAQs | `+faqs-page/faqs-block.component.ts` (page component — **not** named `faqs-page.component.ts`), `.service.ts` | `faqs-block.component.spec.ts`, `faqs-page.service.spec.ts` | `faqs_list.json` |
+| Portfolio | `+portfolio-page/portfolio-page.component.ts`, `.service.ts` + nested `project-details/project-details.component.ts`, `.service.ts` (no `.routes.ts`; routed eagerly from root, see rule registry) | `portfolio-page.component.spec.ts`, `.service.spec.ts`, `project-details.component.spec.ts`, `.service.spec.ts` | `projects.json`, `project_details.json` (filtered client-side by `String(item.id) === String(projectId)`, `project-details.service.ts:15`) |
+| Skills | `+skills-page/skills-page.component.ts`, `.service.ts`, `skills.interface.ts` (only service with a typed return: `Observable<SkillsInterface[]>`) | `skills-page.component.spec.ts`, `.service.spec.ts` | `skills_list.json`, `skills_content.json` |
+| Navigation | `shared/navigation/navigation.component.ts`, `.service.ts`, `navigation-items.ts`, `navigation.inteface.ts` (typo'd filename) | `navigation.component.spec.ts`, `.service.spec.ts` | none (static in-memory array) |
+| Browser gate | `shared/browser-detect/browser-detect.service.ts` (Bowser-based), `shared/browser-unsupported/browser-unsupported.component.ts` | `browser-detect.service.spec.ts`, `browser-unsupported.component.spec.ts` | none |
+| Meta tags | `shared/meta-tags/meta-tags.service.ts` | `meta-tags.service.spec.ts`; consumers use `src/testing/meta-stubs.ts` (`metaSpy`, `titleSpy`, `metaTagsServiceStub`) | none |
+| App shell | `app.component.ts/html`, `app.module.ts`, `app.routes.ts`, `animations.ts` | `app.component.spec.ts` | none |
+| 404 | `404-page/page-not-found.component.ts` (eager, `PageNotFoundModule` imported directly in `AppModule`, `app.module.ts:15,33`) | `page-not-found.component.spec.ts` | none |
+
+Full JSON fixture inventory (`src/assets/data/projectdissimilar/`): `career_progression.json`, `education.json`, `faqs_list.json`, `positions.json`, `profile_pictures.json`, `project_details.json`, `projects.json`, `skills_content.json`, `skills_list.json`, `social_icons.json`.
+
+## Domain pages
+
+| Page | Type | Covers |
+|---|---|---|
+| [feature-page-pattern.md](./feature-page-pattern.md) | Convention | The canonical component/module/routes/service shape and every deviation from it across the 6 feature-page folders. |
+| [routing-and-animation.md](./routing-and-animation.md) | ControlFlow | How `app.routes.ts` → `app.component.html` → `app.component.ts` → `animations.ts` cooperate to animate route transitions; the eager `ProjectDetailsComponent` route. |
+| [shared-infrastructure.md](./shared-infrastructure.md) | Subsystem | `SharedModule`/`MaterialModule` composition, navigation-vs-routes mismatch, browser gate, meta-tags quirks. |
+| [testing.md](./testing.md) | Playbook | Jest config, coverage thresholds, jsdom mock rationale, canonical service-spec and component-spec patterns to copy for new tests. |
+
+Not documented as separate pages (greppable in one file, or a single CI/config file already fully described above): individual feature components/templates, the SCSS tree, `.angular-cli.json`/`.releaserc.json`/`tsconfig*.json` contents beyond what's in this map, `environments/*.ts`.
+
+## Provenance
+
+See [repos.json](./repos.json) for machine-readable provenance and [log.md](./log.md) for the append-only change history. Staleness is enforced by [lint/lint.js](./lint/lint.js) — see [lint/README.md](./lint/README.md).

--- a/docs/wiki/lint/README.md
+++ b/docs/wiki/lint/README.md
@@ -1,0 +1,68 @@
+# Wiki Staleness Linter
+
+Zero-dependency Node script (`lint.js`, runs on Node 10 and Node 22 — no syntax beyond what both support). Lives in `docs/wiki/lint/`, checks pages in `docs/wiki/`.
+
+**The linter flags. It does not fix.** Re-verifying a stale page against current code and re-anchoring it to a new SHA is a deliberate step — done by a human or a follow-up agent run that reads the diff, confirms the wiki's claims still hold (or updates them), and bumps the `anchors` frontmatter to the new SHA. Never automate that step away; that's what keeps the wiki trustworthy at query time.
+
+**Drift is the primary failure mode of this whole system.** Expect the linter to flag pages after unrelated commits touch an anchored file — that's it working as intended, not a bug. Treat "run the linter, see red, go fix or acknowledge" as a normal loop, not an exception.
+
+## Mode A — git staleness (default, gates CI)
+
+```bash
+node docs/wiki/lint/lint.js
+```
+
+For every wiki page:
+1. Parses the `anchors` list from its frontmatter (`path@sha` or `path#Symbol@sha`).
+2. For each anchor, fetches the file content at `sha` via `git show <sha>:<path>` and compares it, **whitespace-normalized** (all runs of whitespace collapsed to one space, then trimmed — so pure reformatting doesn't trip a false positive), against the file's current working-tree content.
+3. Symbol anchors (`path#Symbol@sha`) do not get AST-level extraction in this implementation (no tree-sitter dependency in the stack) — they fall back to a **file-level** comparison and the output says so explicitly: `(symbol granularity unavailable — file-level check)`.
+4. Prints one line per anchor:
+   - `ok <page> ← <path>` — unchanged (whitespace-normalized) since the anchor SHA.
+   - `STALE <page> ← <path> — changed in <short-sha> by <author> (<date>)` — content differs; author/commit come from `git log <sha>..HEAD -- <path>`.
+   - `STALE <page> ← <path> — deleted since <sha>` — anchored file no longer exists.
+   - `ERROR <page> — <reason>` — malformed anchor or missing/invalid `type` in frontmatter.
+5. **Exits non-zero if any page is stale or errored**, zero otherwise — safe to gate CI or a pre-commit hook on the exit code alone.
+
+## Mode B — prose health (on-demand, report-only, never gates)
+
+```bash
+node docs/wiki/lint/lint.js --prose
+```
+
+Reports, does not auto-fix:
+- **Orphan pages** — any page other than `index.md`/`log.md` with no inbound `](./page.md)` link from another wiki page.
+- **Broken cross-links** — a `](./file.md)` reference to a file that doesn't exist in `docs/wiki/`.
+- **Missing/invalid frontmatter** — no `type` field.
+- Prints a closing note that **contradiction detection** and **"concept mentioned but lacking a page" detection** are not automated here — they require semantic judgement a script can't reliably make. Do that check manually (or via an LLM agent read of the whole wiki) when it matters, e.g. before a release of the wiki itself.
+
+Exits 0 always — this mode informs, it never blocks a build.
+
+## Pre-commit hook snippet
+
+```bash
+#!/usr/bin/env bash
+# .git/hooks/pre-commit (or wire via husky/lefthook)
+if git diff --cached --name-only | grep -q '^docs/wiki/'; then
+  node docs/wiki/lint/lint.js || {
+    echo "docs/wiki has stale anchors — see output above. Re-verify and re-anchor before committing."
+    exit 1
+  }
+fi
+```
+
+## CI snippet
+
+```yaml
+  wiki-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # anchors reference historical SHAs; shallow clones break `git show <sha>:<path>`
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: node docs/wiki/lint/lint.js
+```
+
+Add as its own job (parallel to `lint`/`test` in `.github/workflows/ci.yml`) rather than folding into an existing job, so a stale wiki page fails visibly and independently of the app's own lint/test/build.

--- a/docs/wiki/lint/lint.js
+++ b/docs/wiki/lint/lint.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Staleness + prose-health linter for docs/wiki.
+ * Zero dependencies — plain Node (works on Node 10 and Node 22).
+ * See docs/wiki/lint/README.md for usage and CI wiring.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const WIKI_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(WIKI_DIR, '..', '..');
+
+function git(args) {
+  return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+function listWikiPages() {
+  return fs
+    .readdirSync(WIKI_DIR)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => path.join(WIKI_DIR, f));
+}
+
+// --- minimal frontmatter parser -------------------------------------------
+// Our frontmatter is a controlled, flat subset of YAML: `key: value` scalars
+// and `key:` followed by `  - item` list entries. Good enough without a YAML
+// dependency; anything fancier should switch to a real parser.
+function parseFrontmatter(raw) {
+  const match = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const lines = match[1].split('\n');
+  const data = {};
+  let currentKey = null;
+  for (const line of lines) {
+    const listItem = line.match(/^\s*-\s*(.+)$/);
+    if (listItem && currentKey) {
+      data[currentKey] = data[currentKey] || [];
+      data[currentKey].push(listItem[1].trim().replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+    const kv = line.match(/^([A-Za-z_]+):\s*(.*)$/);
+    if (kv) {
+      currentKey = kv[1];
+      const value = kv[2].trim();
+      if (value === '' ) {
+        data[currentKey] = data[currentKey] || [];
+      } else if (value === '[]') {
+        data[currentKey] = [];
+      } else {
+        data[currentKey] = value.replace(/^['"]|['"]$/g, '');
+      }
+    }
+  }
+  return data;
+}
+
+function normalizeWhitespace(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+// path@sha  OR  path#Symbol@sha
+function parseAnchor(anchor) {
+  const at = anchor.lastIndexOf('@');
+  if (at === -1) return null;
+  const sha = anchor.slice(at + 1);
+  const left = anchor.slice(0, at);
+  const hash = left.indexOf('#');
+  if (hash === -1) return { filePath: left, symbol: null, sha };
+  return { filePath: left.slice(0, hash), symbol: left.slice(hash + 1), sha };
+}
+
+function fileAtSha(sha, filePath) {
+  try {
+    return git(['show', `${sha}:${filePath}`]);
+  } catch (e) {
+    return null; // file didn't exist at that sha, or sha unknown
+  }
+}
+
+function currentFileContent(filePath) {
+  const abs = path.join(REPO_ROOT, filePath);
+  if (!fs.existsSync(abs)) return null;
+  return fs.readFileSync(abs, 'utf8');
+}
+
+function lastCommitTouching(sha, filePath) {
+  try {
+    const out = git([
+      'log',
+      '-1',
+      '--format=%h|%an|%ad',
+      '--date=short',
+      `${sha}..HEAD`,
+      '--',
+      filePath
+    ]).trim();
+    if (!out) return null;
+    const [commit, author, date] = out.split('|');
+    return { commit, author, date };
+  } catch (e) {
+    return null;
+  }
+}
+
+// --- Mode A: git staleness --------------------------------------------------
+function runStaleness() {
+  const pages = listWikiPages();
+  let anyStale = false;
+  const results = [];
+
+  for (const pagePath of pages) {
+    const raw = fs.readFileSync(pagePath, 'utf8');
+    const fm = parseFrontmatter(raw);
+    const pageName = path.relative(WIKI_DIR, pagePath);
+
+    if (!fm || !fm.type) {
+      results.push({ page: pageName, status: 'ERROR', detail: 'missing or invalid frontmatter (no `type`)' });
+      anyStale = true;
+      continue;
+    }
+
+    const anchors = fm.anchors || [];
+    if (anchors.length === 0) {
+      results.push({ page: pageName, status: 'ok', detail: '(no anchors — Index/Log page)' });
+      continue;
+    }
+
+    for (const rawAnchor of anchors) {
+      const parsed = parseAnchor(rawAnchor);
+      if (!parsed) {
+        results.push({ page: pageName, status: 'ERROR', detail: `malformed anchor "${rawAnchor}"` });
+        anyStale = true;
+        continue;
+      }
+
+      const { filePath, symbol, sha } = parsed;
+      const oldContent = fileAtSha(sha, filePath);
+      const newContent = currentFileContent(filePath);
+
+      if (oldContent === null) {
+        results.push({ page: pageName, status: 'STALE', detail: `${filePath}@${sha} — anchor sha/path not resolvable via git show` });
+        anyStale = true;
+        continue;
+      }
+      if (newContent === null) {
+        results.push({ page: pageName, status: 'STALE', detail: `${filePath} — deleted since ${sha}` });
+        anyStale = true;
+        continue;
+      }
+
+      let oldBody = oldContent;
+      let newBody = newContent;
+      let symbolNote = '';
+      if (symbol) {
+        symbolNote = ' (symbol granularity unavailable — file-level check)';
+      }
+
+      if (normalizeWhitespace(oldBody) === normalizeWhitespace(newBody)) {
+        results.push({ page: pageName, status: 'ok', detail: `${filePath}${symbol ? '#' + symbol : ''}${symbolNote}` });
+        continue;
+      }
+
+      const commitInfo = lastCommitTouching(sha, filePath);
+      const who = commitInfo
+        ? `changed in ${commitInfo.commit} by ${commitInfo.author} (${commitInfo.date})`
+        : 'changed since anchor sha (commit info unavailable)';
+      results.push({
+        page: pageName,
+        status: 'STALE',
+        detail: `${filePath}${symbol ? '#' + symbol : ''}${symbolNote} — ${who}`
+      });
+      anyStale = true;
+    }
+  }
+
+  for (const r of results) {
+    if (r.status === 'ok') {
+      console.log(`ok ${r.page} ← ${r.detail}`);
+    } else if (r.status === 'STALE') {
+      console.log(`STALE ${r.page} ← ${r.detail}`);
+    } else {
+      console.log(`ERROR ${r.page} — ${r.detail}`);
+    }
+  }
+
+  return anyStale ? 1 : 0;
+}
+
+// --- Mode B: prose health (report-only) -------------------------------------
+function runProse() {
+  const pages = listWikiPages();
+  const pageMeta = pages.map((p) => {
+    const raw = fs.readFileSync(p, 'utf8');
+    return { file: p, name: path.basename(p), raw, fm: parseFrontmatter(raw) };
+  });
+
+  let issues = 0;
+
+  // Broken frontmatter
+  for (const p of pageMeta) {
+    if (!p.fm || !p.fm.type) {
+      console.log(`ISSUE ${p.name}: missing or invalid frontmatter (no \`type\`)`);
+      issues++;
+    }
+  }
+
+  // Cross-links: ](./file.md) style relative links within docs/wiki
+  const linkRe = /\]\(\.\/([A-Za-z0-9_\-./]+\.md)(#[^)]*)?\)/g;
+  const inbound = {};
+  for (const p of pageMeta) inbound[p.name] = 0;
+
+  for (const p of pageMeta) {
+    let m;
+    linkRe.lastIndex = 0;
+    while ((m = linkRe.exec(p.raw))) {
+      const target = m[1];
+      const targetPath = path.join(WIKI_DIR, target);
+      if (!fs.existsSync(targetPath)) {
+        console.log(`ISSUE ${p.name}: broken cross-link → ./${target}`);
+        issues++;
+        continue;
+      }
+      inbound[target] = (inbound[target] || 0) + 1;
+    }
+  }
+
+  // Orphan pages: no inbound links, excluding index.md/log.md which are entry points
+  for (const p of pageMeta) {
+    if (p.name === 'index.md' || p.name === 'log.md') continue;
+    if (!inbound[p.name]) {
+      console.log(`ISSUE ${p.name}: orphan page — no inbound link from index.md or another wiki page`);
+      issues++;
+    }
+  }
+
+  if (issues === 0) {
+    console.log('prose-health: no issues found (orphans, broken links, missing frontmatter)');
+  }
+  console.log(
+    '\nNote: contradiction detection and "concept mentioned but lacking a page" detection are not ' +
+      'automated by this script — they require semantic judgement. Review new pages manually against ' +
+      'this list when running --prose.'
+  );
+
+  return 0; // prose mode is report-only, never gates a build
+}
+
+// --- entrypoint --------------------------------------------------------------
+function main() {
+  const mode = process.argv.includes('--prose') ? 'prose' : 'staleness';
+  const exitCode = mode === 'prose' ? runProse() : runStaleness();
+  process.exit(exitCode);
+}
+
+main();

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,0 +1,29 @@
+---
+type: Log
+title: Wiki Change Log
+description: Append-only history of wiki builds and re-anchors for docs/wiki.
+resource: https://github.com/commitBlob/folioAngular/blob/c4391ece5b07a47b84f5591808f3588a37f9ea7c/docs/wiki
+tags: [log]
+timestamp: 2026-07-08T00:00:00Z
+anchors: []
+---
+
+# Wiki Change Log
+
+Append entries to the top... no — append to the **bottom**, newest last, so `grep "^## \[" log.md | tail` shows the most recent entries. Every entry starts with `## [YYYY-MM-DD] <op> | <summary>`.
+
+## [2026-07-08] build | Initial wiki build, anchor c4391ece5b07a47b84f5591808f3588a37f9ea7c
+
+Scope: `INGEST_SCOPE=root`, full repo (189 tracked files, ~90 TS sources under `src/app/`). Repo assessed as small/highly-greppable (operating principle 6) — produced the dense `index.md` map plus 4 domain pages that each clear the N_COMPRESS=3 bar:
+
+- `feature-page-pattern.md` — spans 6 feature-page folders (~30 files); corrects CLAUDE.md's false "same four files" claim.
+- `routing-and-animation.md` — non-obvious control flow across 4 files (`app.routes.ts`, `app.component.ts/html`, `animations.ts`).
+- `shared-infrastructure.md` — coupling invisible from any single file across 6 files under `src/app/shared/`.
+- `testing.md` — Jest config + jsdom mock rationale + spec patterns spanning ~25 spec files + 4 infra files.
+
+Also updated root `CLAUDE.md` to link to this wiki, fix the "same four files" overstatement, and correct/flag the Docker/nginx paragraph (referenced files not present in the tracked tree as of this SHA).
+
+Flagged as UNKNOWN / discrepancy (code wins, doc did not match):
+- `nginx-custom.conf` / `Dockerfile` referenced by prior `CLAUDE.md` — absent from `git ls-files` at this SHA.
+- `src/index.html:5` page `<title>` role string vs `MetaTagsService.roleTitle` (`meta-tags.service.ts:7`) — two disagreeing sources of truth, not resolved by this run.
+- `MetaTagsService.setTwitterCard()` uses `value` instead of `content` (`meta-tags.service.ts:25-27`) — flagged, not changed (documentation task, not a bug-fix task).

--- a/docs/wiki/repos.json
+++ b/docs/wiki/repos.json
@@ -1,0 +1,8 @@
+{
+  "repo_url": "https://github.com/commitBlob/folioAngular",
+  "default_branch": "master",
+  "init_sha": "c4391ece5b07a47b84f5591808f3588a37f9ea7c",
+  "last_sha": "c4391ece5b07a47b84f5591808f3588a37f9ea7c",
+  "ingest_scope": "root",
+  "structure_fingerprint": "sha256:2471cf2ed41e87e08b71f2eb86590d43202e339eb8f7b4bb9a0eec35b12fb6e6"
+}

--- a/docs/wiki/routing-and-animation.md
+++ b/docs/wiki/routing-and-animation.md
@@ -1,0 +1,70 @@
+---
+type: ControlFlow
+title: Routing and Router-Transition Animation
+description: How the root route table, app shell template, and the routerAnimation trigger cooperate to slide pages in and out on navigation.
+resource: https://github.com/commitBlob/folioAngular/blob/c4391ece5b07a47b84f5591808f3588a37f9ea7c/src/app/app.routes.ts
+tags: [control-flow, routing, animation, footgun]
+timestamp: 2026-07-08T00:00:00Z
+anchors:
+  - src/app/app.routes.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/animations.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.html@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+---
+
+# Routing and Router-Transition Animation
+
+## Why this page exists
+
+The slide transition between pages is wired across 4 files with no single file showing the full path from "user navigates" to "trigger fires with the right value." This is the kind of non-obvious control flow operating principle 1 calls out.
+
+## The flow
+
+1. **`src/app/app.routes.ts`** — each top-level `Route` carries `data: { animation: '<name>' }` (verbatim values below). Lazy pages use pre-Ivy string `loadChildren`, e.g. `loadChildren: 'app/+about-page/about-page.module#AboutPageModule'` (`app.routes.ts:17`) — app-root-relative path, `#` before the exported module class name. This string form is why the app cannot move to Ivy/dynamic-import `loadChildren` without a framework upgrade.
+
+   | Route | `data.animation` | Notes |
+   |---|---|---|
+   | `''` (redirect → `about`) | `'home'` | `app.routes.ts:9-14` |
+   | `about` | `'about'` | lazy, `about-page.module#AboutPageModule` |
+   | `contact` | `'contact'` | lazy |
+   | `portfolio` | `'portfolio'` | lazy |
+   | `skills` | `'skills'` | lazy |
+   | `experience` | `'experience'` | lazy |
+   | `faqs` | **none** | lazy; `data` key omitted entirely — `app.routes.ts:40-43` |
+   | `portfolio/:project` | `'project-details'` | **eager** `component: ProjectDetailsComponent` — not lazy-loaded, imported directly at `app.routes.ts:6` |
+   | `**` | **none** | `component: PageNotFoundComponent`, `app.routes.ts:49-52` |
+
+2. **`src/app/app.component.html:10-11`** binds the trigger to the outlet's route data via a template reference variable:
+   ```html
+   <div [@routerAnimation]="getRouteAnimation(route)">
+     <router-outlet #route="outlet"></router-outlet>
+   </div>
+   ```
+   `#route="outlet"` exposes the `RouterOutlet` directive instance (not the `ActivatedRoute`) as `route`, which is what gets passed into `getRouteAnimation`.
+
+3. **`src/app/app.component.ts:29-31`** reads the animation key from the outlet, not from `ActivatedRoute.snapshot.data`:
+   ```ts
+   getRouteAnimation(outlet) {
+     return outlet.activatedRouteData.animation;
+   }
+   ```
+   For `faqs` and `**`, this returns `undefined` — the transition (see below) still runs on `'* <=> *'` (any-state-change), but with an `undefined` binding value, so don't assume every route has a distinguishable animation identity.
+
+4. **`src/app/animations.ts:9-41`** defines the trigger consumed by the `animations: [routerAnimation]` array on `AppComponent` (`app.component.ts:11`):
+   - `transition('* <=> *', [...])` — fires on **any** state change, including to/from `undefined`.
+   - `:enter` starts at `position: fixed; width: 100%; transform: translateX(-150%)`.
+   - `:leave` animates to `position: fixed; width: 100%; transform: translateX(120%)` over `500ms ease-in`, `delay: 100`.
+   - `:enter` then animates to `opacity: 1; transform: translateX(0%)` over `800ms ease-out`, `delay: 200`.
+   - All three `query()` calls use `{optional: true}` so a missing enter/leave element doesn't throw.
+   - **Footgun:** both outgoing and incoming views are `position: fixed` simultaneously during the overlap window — any other fixed-position element sharing the viewport can visually collide during the ~600ms transition.
+
+5. **Gating before any of this runs:** `AppComponent` only renders the router-outlet branch if `browserSupported` is true (`app.component.html:1-2`, `*ngIf="!browserSupported else isChromeOrFF"`), set once in the constructor from `BrowserDetectService.chromeOrFirefoxCheck()` (`app.component.ts:17-18`). See [shared-infrastructure.md](./shared-infrastructure.md) for the browser gate itself.
+
+6. Root wiring: `RouterModule.forRoot(routes)` and `SharedModule.forRoot()` in `AppModule.imports` (`app.module.ts:34-35`); `PageNotFoundModule` (holding `PageNotFoundComponent`) is imported **eagerly**, unlike every lazy feature module (`app.module.ts:15,33`).
+
+## Practical implications
+
+- Adding a new top-level route: give it a unique `data: { animation: '<name>' }` or accept it'll share the `undefined` bucket with `faqs`/`**`.
+- The animation trigger has no per-route customization — all transitions use the same timings/easings regardless of `data.animation`'s value; the key only exists to force Angular to see a state change on the `[@routerAnimation]` binding (`'* <=> *'` matches any transition where the bound value differs, including `undefined → 'about'`).
+- `ProjectDetailsComponent` is the one page reachable without a lazy chunk load — if profiling initial bundle size, it's already in the main bundle via `SharedModule → ProjectDetailsModule`.

--- a/docs/wiki/shared-infrastructure.md
+++ b/docs/wiki/shared-infrastructure.md
@@ -1,0 +1,60 @@
+---
+type: Subsystem
+title: Shared Infrastructure
+description: SharedModule/MaterialModule composition, the navigation-items vs route-table mismatch, the Bowser-based browser gate, and MetaTagsService quirks.
+resource: https://github.com/commitBlob/folioAngular/blob/c4391ece5b07a47b84f5591808f3588a37f9ea7c/src/app/shared
+tags: [subsystem, di, navigation, browser-detection, meta-tags, footgun]
+timestamp: 2026-07-08T00:00:00Z
+anchors:
+  - src/app/shared/shared.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/materialModule.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/navigation/navigation-items.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/navigation/navigation.inteface.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/navigation/navigation.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/navigation/navigation.module.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/browser-detect/browser-detect.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/shared/meta-tags/meta-tags.service.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.html@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+---
+
+# Shared Infrastructure
+
+## Why this page exists
+
+Five small files under `src/app/shared/` each look trivial in isolation, but together they encode coupling and mismatches invisible from any one of them: `SharedModule`'s re-export-without-import and reach into a feature subfolder, a navigation list that silently omits a real route, and a browser gate whose exact allowlist matters for who sees the app at all. Six source files, one page.
+
+## `SharedModule` (`src/app/shared/shared.module.ts`)
+
+- `imports`: `CommonModule, MaterialModule, RouterModule, ReactiveFormsModule` (lines 13-17).
+- `exports`: `CommonModule, FormsModule, MaterialModule, NavigationModule, ProjectDetailsModule, RouterModule, ReactiveFormsModule` (19-27).
+- **`FormsModule` is exported but never imported** in this module — legal Angular (re-exporting doesn't require importing), but easy to misdiagnose as a missing import if `FormsModule`-dependent directives fail to resolve elsewhere.
+- **Depends on a feature subfolder:** imports `ProjectDetailsModule` from `../+portfolio-page/project-details/project-details.module` (line 10) and re-exports it (line 24) — so `SharedModule` is not purely generic infrastructure; any module importing `SharedModule` transitively gets the portfolio project-details component. This is also how the eagerly-routed `ProjectDetailsComponent` (see [routing-and-animation.md](./routing-and-animation.md)) becomes available without the portfolio lazy chunk.
+- `forRoot()` (32-37) returns `{ ngModule: SharedModule, providers: [] }` — a no-op provider-wise. Only `AppModule` calls `SharedModule.forRoot()` (`app.module.ts:35`); every feature module imports plain `SharedModule`. There is currently no reason `forRoot()` needs to exist (empty `providers`), but changing/removing it changes `AppModule`'s import shape — leave it unless doing a deliberate cleanup.
+
+## `MaterialModule` (`src/app/shared/materialModule.ts`)
+
+Single-barrel import from `@angular/material` (Angular 5 style — this pattern is removed in later Angular Material versions, so this file cannot survive an Angular Material upgrade unchanged). Modules re-exported (lines 18-29): `MatTabsModule, MatCardModule, MatCheckboxModule, MatInputModule, MatSelectModule, MatButtonModule, MatDialogModule, MatTooltipModule, MatDatepickerModule, MatExpansionModule`. Providers (38-42) wire the Moment date adapter for `MatDatepickerModule`: `DateAdapter → MomentDateAdapter`, `MAT_DATE_FORMATS → MAT_MOMENT_DATE_FORMATS`, `MAT_DATE_LOCALE → 'en-GB'`. Imported both by `AppModule` directly (`app.module.ts:13,32`) and via `SharedModule`/individual feature modules (e.g. `faqs-page.module.ts:7,14`, `contact-page.module.ts:11,17`) — i.e. some feature modules import it directly rather than relying on `SharedModule`'s re-export.
+
+## Navigation (`src/app/shared/navigation/`)
+
+- **Filename/identifier typo, load-bearing:** the interface file is `navigation.inteface.ts` (missing "r"), exporting `interface NavigationInteface { linkName: string; linkPath: string; linkIcon: string; linkSubName?: string; }` (`navigation.inteface.ts:1-6`). Any new code referencing navigation types must import this exact misspelled name — grepping for "interface" (correctly spelled) will not find this file.
+- `navigation-items.ts:3-30` exports `const GlobalNavigation: NavigationInteface[]`, a **static, hardcoded** array, 5 entries in display order: `about` (`fas fa-user`), `skills` (`fab fa-superpowers`, with `linkSubName: 'SKILLS'` — displayed label is "SUPERPOWERS"), `experience` (`fas fa-road`), `portfolio` (`fas fa-cubes`), `contact` (`fas fa-envelope`).
+- **`faqs` is a real, routable page (`app.routes.ts:40-43`) that is absent from `GlobalNavigation`** — it's reachable only by direct URL, never surfaced in the nav UI. If asked to "add a link for every page," don't assume the current nav list is the full route set.
+- `NavigationService.getNavigation()` (`navigation.service.ts:9-11`) just returns `GlobalNavigation` verbatim — no filtering, no async, no HTTP. `NavigationModule` (`navigation.module.ts`) declares/exports `NavigationComponent` and provides `NavigationService`.
+
+## Browser gate
+
+- `BrowserDetectService.chromeOrFirefoxCheck()` (`browser-detect.service.ts:8-13`) uses **Bowser 2.x**: `Bowser.getParser(window.navigator.userAgent).getBrowserName()`, then `return (browserName === 'Chrome' || browserName === 'Firefox')`. This is **string equality against Bowser's canonical browser name**, not a user-agent regex — any browser Bowser doesn't label exactly `'Chrome'` or `'Firefox'` (Edge, Safari, Chromium-based forks, etc.) fails the check.
+- Consumed once, in `AppComponent`'s constructor: `this.browserSupported = browserService.chromeOrFirefoxCheck();` (`app.component.ts:17-18`) — computed once at app bootstrap, not reactive to anything.
+- Template gate: `app.component.html:1-2` — `<app-browser-unsupported *ngIf="!browserSupported else isChromeOrFF">`, with the entire real UI (nav, burger menu, animated router-outlet) inside the `#isChromeOrFF` `ng-template`. Failing the check means `BrowserUnsupportedComponent` renders and nothing else in the app tree ever mounts (no router, no nav).
+
+## `MetaTagsService` (`src/app/shared/meta-tags/meta-tags.service.ts`)
+
+Stateless helper (no HTTP), fields: `roleTitle = 'Senior Software Developer & Research Lead'`, `name = 'Maro Radovic'`, `currentCompany = 'Ntegra'` (lines 7-9). Methods build Angular `Meta`/`Title` payloads (never call `Meta`/`Title` themselves — callers do that):
+- `setPageTitle(page)` → `` `${name} - ${roleTitle} | ${page}` `` (11-13).
+- `setDescriptionMetaTag()` → `{name: 'description', content: ...}` interpolating `name`/`currentCompany`/`roleTitle` (15-19).
+- `setMetaTag(tagName, tagContent)` → generic `{name, content}` passthrough (21-23).
+- `setTwitterCard()` → `{name: 'twitter:card', value: 'summary'}` — **uses `value`, not `content`**, inconsistent with every other method here and with the real `content` key Angular's `Meta.addTag` expects for a `<meta>` tag; verify before relying on this for actual Twitter Card rendering. (21-27)
+- `setContentType()` → `{httpEquiv: 'Content-Type', content: 'text/html', charset: 'utf-8'}` (29-31).
+- **Cross-file mismatch:** `roleTitle` here (`'Senior Software Developer & Research Lead'`) disagrees with the static `<title>` in `src/index.html:5` (`'AI Solution Architect & Lead Forward Deployed Engineer'`). The dynamic per-page title (via `setPageTitle`, used by e.g. `FaqsBlockComponent.setMetaData()`, `faqs-block.component.ts:40-43`) overwrites the static one after bootstrap, so which string a user sees depends on timing/JS execution — treat both as sources of truth that need to agree, not just one.

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,0 +1,85 @@
+---
+type: Playbook
+title: Testing Playbook
+description: Jest configuration, coverage thresholds, jsdom mock rationale, and the canonical service-spec / component-spec patterns to copy for new tests.
+resource: https://github.com/commitBlob/folioAngular/blob/c4391ece5b07a47b84f5591808f3588a37f9ea7c/jest.config.js
+tags: [playbook, testing, jest, coverage]
+timestamp: 2026-07-08T00:00:00Z
+anchors:
+  - jest.config.js@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/setup-jest.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/setup-jest-global-mocks.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/testing/meta-stubs.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/+about-page/about-page.service.spec.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+  - src/app/app.component.spec.ts@c4391ece5b07a47b84f5591808f3588a37f9ea7c
+---
+
+# Testing Playbook
+
+## Why this page exists
+
+New tests need to match an established pattern (Jest + `jest-preset-angular`, specific mock providers, a specific coverage gate) that spans 4 infra files plus ~25 spec files. Getting any of this wrong either fails CI (`test:ci` enforces coverage thresholds) or silently duplicates jsdom shims that already exist globally.
+
+## Configuration (`jest.config.js`)
+
+```js
+preset: 'jest-preset-angular'
+setupTestFrameworkScriptFile: '<rootDir>/src/setup-jest.ts'
+roots: ['<rootDir>/src']
+globals: { 'ts-jest': { tsConfigFile: 'src/tsconfig.spec.json' }, __TRANSFORM_HTML__: true }
+```
+(`jest.config.js:1-10`)
+
+Coverage (`jest.config.js:11-28`):
+- `collectCoverageFrom`: `src/app/**/*.ts` **excluding** `**/*.module.ts`, `**/*.routes.ts`, `**/*.spec.ts`, `src/testing/**`.
+- **Global thresholds (exact, hard gate on `npm run test:ci`):** `statements: 90, branches: 80, functions: 90, lines: 90`.
+- Reporters: `html`, `lcovonly`, `text-summary`; output dir `<rootDir>/coverage` (uploaded as a CI artifact regardless of pass/fail, `.github/workflows/ci.yml:35-39`).
+
+## Bootstrap files
+
+- `src/setup-jest.ts` (`setupTestFrameworkScriptFile`) — two lines: `import 'jest-preset-angular'; import './setup-jest-global-mocks';`. This replaces the Karma-era `src/test.ts`.
+- `src/setup-jest-global-mocks.ts` — stubs browser APIs jsdom doesn't implement, applied to **every** test file globally:
+  - `localStorage`/`sessionStorage` — in-memory closure-backed mock (lines 4-15).
+  - `window.matchMedia` → `{ matches: false, addListener, removeListener }` (17-23) — comment: "Angular Material reads matchMedia/getComputedStyle on init."
+  - `window.getComputedStyle` → `{ getPropertyValue: () => '' }` (25-29).
+  - `Element.prototype.scrollIntoView` → no-op, `writable: true` (31-34) — needed because `ExperiencePageComponent` calls `scrollIntoView` (see `experience-page.component.ts`); without this mock any spec touching that component throws in jsdom.
+- `src/testing/meta-stubs.ts` — shared fakes for the `Meta`/`Title`/`MetaTagsService` trio reused across page-component specs, deliberately excluded from coverage (not imported by production code):
+  - `metaSpy()` → `{ addTag: jest.fn(), addTags: jest.fn() }`
+  - `titleSpy()` → `{ setTitle: jest.fn() }`
+  - `metaTagsServiceStub()` → fake implementations of all 5 `MetaTagsService` methods (see [shared-infrastructure.md](./shared-infrastructure.md) for the real ones).
+
+## Canonical service-spec pattern
+
+`HttpClientTestingModule` + `HttpTestingController`, one `describe` per service. From `about-page.service.spec.ts:1-19` (identical shape reused across every HTTP-backed service spec, e.g. `portfolio-page.service.spec.ts`):
+
+```ts
+TestBed.configureTestingModule({
+  imports: [HttpClientTestingModule],
+  providers: [AboutPageService]
+});
+service = TestBed.get(AboutPageService);
+httpMock = TestBed.get(HttpTestingController);
+jest.spyOn(console, 'error').mockImplementation(() => {}); // silence handleError's console.error
+```
+`afterEach(() => httpMock.verify())` (line 19) ensures no unexpected outstanding requests. Assertions use `httpMock.expectOne('<exact relative URL>')`, check `req.request.method === 'GET'`, then `req.flush(data)` for the happy path or `req.error(new ErrorEvent(...))` to exercise the `catch`/`handleError` branch (`about-page.service.spec.ts:41-58` also unit-tests `handleError` directly by casting the service `as any` to reach the private method).
+
+## Canonical component-spec pattern
+
+From `app.component.spec.ts:1-23`: provide hand-rolled `jest.fn()`-based stubs for injected services (never the real service), use `NO_ERRORS_SCHEMA` to skip unknown child-element errors, and `overrideComponent(X, { set: { template: '', animations: [] } })` to strip the real template/animations when the spec only exercises component-class logic:
+
+```ts
+TestBed.configureTestingModule({
+  declarations: [AppComponent],
+  providers: [{ provide: BrowserDetectService, useValue: browserService }],
+  schemas: [NO_ERRORS_SCHEMA]
+}).overrideComponent(AppComponent, { set: { template: '', animations: [] } });
+```
+
+Page components that need `Meta`/`Title`/`MetaTagsService` should provide `metaSpy()`/`titleSpy()`/`metaTagsServiceStub()` from `src/testing/meta-stubs.ts` rather than re-declaring fakes inline.
+
+## Checklist for a new spec
+
+1. Service spec → `HttpClientTestingModule` + `HttpTestingController`, silence `console.error`, `httpMock.verify()` in `afterEach`, assert on the exact `'./assets/data/projectdissimilar/<name>.json'` URL string.
+2. Component spec → stub every injected service with `jest.fn()`-based providers (or the shared `meta-stubs.ts` helpers), `NO_ERRORS_SCHEMA` + `overrideComponent` if you only need class-level behavior.
+3. Check `jest.config.js`'s `collectCoverageFrom` excludes before assuming a new `.module.ts`/`.routes.ts` needs its own spec — those are intentionally uncovered.
+4. Run `npm run test:ci` locally before pushing; it fails the whole suite if global coverage drops below 90/80/90/90 (statements/branches/functions/lines).


### PR DESCRIPTION
Adds docs/wiki/ — a dense, OKF v0.1-conformant map (index.md) plus 4 domain pages (feature-page pattern & its real deviations, routing + router-animation control flow, shared infrastructure, testing playbook) anchored to git SHA c4391ece, each backed by verified path:line citations. Includes a zero-dependency Node staleness linter (docs/wiki/lint/lint.js) with git-anchor diffing and a report-only prose-health mode, plus its README with CI/pre-commit snippets.

Updates root CLAUDE.md to link to the wiki, correct the inaccurate "same four files" claim about feature pages, and flag the Docker/nginx paragraph as unverified (no such files exist in the tracked tree).